### PR TITLE
turned off top level and clip contents

### DIFF
--- a/vsk_ui/account_action_menu.tscn
+++ b/vsk_ui/account_action_menu.tscn
@@ -85,8 +85,6 @@ size_flags_vertical = 3
 theme_type_variation = &"MenuMarginContainer"
 
 [node name="TopLevelContent" type="Control" parent="Panel/Content/Body/Control/MarginContainer"]
-top_level = true
-clip_contents = true
 layout_mode = 2
 
 [node name="SubBody" type="VBoxContainer" parent="Panel/Content/Body/Control/MarginContainer/TopLevelContent"]


### PR DESCRIPTION
Please feel free to reject this PR if the invisible UI elements in the Account Action menu were intentional, but they're now visible and properly centred